### PR TITLE
Disable MCP server in gen.yaml configuration

### DIFF
--- a/.speakeasy/gen.yaml
+++ b/.speakeasy/gen.yaml
@@ -43,7 +43,7 @@ typescript:
   constFieldsAlwaysOptional: true
   defaultErrorName: APIError
   enableCustomCodeRegions: false
-  enableMCPServer: true
+  enableMCPServer: false
   enableReactQuery: false
   enumFormat: union
   envVarPrefix: VANTA


### PR DESCRIPTION
## Changes

Disable the bundled MCP server functionality.

## Motivation

Based on this high-severity security vulnerability reported [here](https://vantahq.slack.com/archives/C044YDVPC3C/p1765460042335269) and the fact that [no one is using the bundled MCP server](https://vantahq.slack.com/archives/C05UKAW1747/p1762875874828539?thread_ts=1762873908.804249&cid=C05UKAW1747), we're disabling it.

We'd have it [disabled on Jan 5 either way, since it's been deprecated by Speakeasy](https://vantahq.slack.com/archives/C07AL5S9RB8/p1762870064951659).