### PR TITLE
fix: add required statusCodes to Speakeasy retries overlay

### DIFF
--- a/.speakeasy/speakeasy-modifications-overlay.yaml
+++ b/.speakeasy/speakeasy-modifications-overlay.yaml
@@ -94,6 +94,12 @@ actions:
           maxInterval: 50
           maxElapsedTime: 100
           exponent: 1.1
+        statusCodes:
+          - "429"
+          - "500"
+          - "502"
+          - "503"
+          - "504"
 
   # Removing extranous endpoints
   - target: $["paths"]["/audits/{auditId}/vendors"]


### PR DESCRIPTION
## Summary

- Adds the required `statusCodes` field to `x-speakeasy-retries` on `GET /audits` in `.speakeasy/speakeasy-modifications-overlay.yaml`
- Uses the same retry status codes the generated SDK already defaults to: `429`, `500`, `502`, `503`, `504`

## Context

Nightly SDK generation has been failing since PR #22 merged with an incomplete `x-speakeasy-retries` block. Speakeasy 1.763.1 lint rejects the post-overlay OpenAPI document with:

```
validation error: x-speakeasy-retries.statusCodes is required
```

## Test plan

- [ ] Merge and confirm the next `Generate` workflow run passes the "Validating Document" step
- [ ] Optionally run `speakeasy run` locally (requires `SPEAKEASY_API_KEY`) to validate end-to-end


Made with [Cursor](https://cursor.com)