### PR TITLE
Include all auditor API endpoints in SDK

### DIFF
--- a/.speakeasy/speakeasy-modifications-overlay.yaml
+++ b/.speakeasy/speakeasy-modifications-overlay.yaml
@@ -110,20 +110,6 @@ actions:
           - "503"
           - "504"
 
-  # Removing extranous endpoints
-  - target: $["paths"]["/audits/{auditId}/vendors"]
-    remove: true
-  - target: $["paths"]["/audits/{auditId}/monitored-computers"]
-    remove: true
-  - target: $["paths"]["/audits/{auditId}/people"]
-    remove: true
-  - target: $["paths"]["/audits/{auditId}/vulnerability-remediations"]
-    remove: true
-  - target: $["paths"]["/audits/{auditId}/vulnerabilities"]
-    remove: true
-  - target: $["paths"]["/audits/{auditId}/vulnerable-assets"]
-    remove: true
-
   # Replacing the servers with the new ones
   - target: $["servers"][*]
     remove: true


### PR DESCRIPTION
## Changes

Remove the `exclude` entries for auditor API endpoints from  `.speakeasy/speakeasy-modifications-overlay.yaml`

## Motivation

The Mintlify public documentation for the auditor API is generated from the Speakeasy SDK rather than directly from the OpenAPI spec. As a result, any endpoint excluded from the SDK is also missing from the public docs, even after it is fully released and available to customers via the API.

Several auditor API endpoints have historically been excluded from the SDK. This left them publicly visible but out of the SDK.

Removing the exclusions brings the SDK — and therefore the docs — back in line with the actual API surface.